### PR TITLE
⚙️ fix: ordem dos ônibus de acordo com código de ordem

### DIFF
--- a/src/components/MovingMarkerSPPO.jsx
+++ b/src/components/MovingMarkerSPPO.jsx
@@ -38,7 +38,7 @@ export default function BusMarkerSPPO({ id, data }) {
                 icon={customMarker}
                 position={[latitude, longitude]}
                 previousPosition={prevPos}
-                duration={6000}
+                duration={1}
                 rotationAngle={0}
                 key={id}
             >

--- a/src/components/MovingMarkersBRT.jsx
+++ b/src/components/MovingMarkersBRT.jsx
@@ -33,7 +33,7 @@ export default function BusMarker({ id, data}) {
             icon={customMarker}
                 position={[data.latitude, data.longitude]}
                 previousPosition={prevPos}
-                duration={6000}
+                duration={1}
                 rotationAngle={0}
                 key={id}
             >

--- a/src/hooks/getMovingMarkers.jsx
+++ b/src/hooks/getMovingMarkers.jsx
@@ -55,7 +55,8 @@ export function MovingMarkerProvider({ children }) {
                 const point = turf.point([item.longitude, item.latitude]);
                 return !scaledGaragePolygons.some(garage => turf.booleanPointInPolygon(point, garage)) && min_latitude <= item.latitude && item.latitude <= max_latitude && min_longitude <= item.longitude && item.longitude <= max_longitude;
             });
-            setTracked(filteredBRT);
+            const sortedBrt =   filteredBRT.sort((a,b) => a.codigo - b.codigo)
+            setTracked(sortedBrt);
 
 
             const uniqueItems = realtimeSPPO.reduce((uniqueItems, item) => {


### PR DESCRIPTION
## Mudanças
- ignora a ordem da API do BRT e é usada o código para ordenar e manter a posição